### PR TITLE
Use start index to offset fetching of photos

### DIFF
--- a/src/picasa.js
+++ b/src/picasa.js
@@ -144,6 +144,7 @@ function getPhotos (accessToken, options, callback) {
   options = options || {}
 
   if (options.maxResults) accessTokenParams['max-results'] = options.maxResults
+  if (options.startIndex) accessTokenParams['start-index'] = options.startIndex
 
   const albumPart = options.albumId ? `/albumid/${options.albumId}` : ''
 


### PR DESCRIPTION
Enables passing start index as an option to offset fetching of photos.