### PR TITLE
Add support for nested key in the extraction of entries

### DIFF
--- a/src/picasa.js
+++ b/src/picasa.js
@@ -169,6 +169,7 @@ function getPhotos (accessToken, options, callback) {
 }
 
 const albumSchema = {
+  'media$group.media$thumbnail' : 'thumbnail',
   'gphoto$id'                : 'id',
   'gphoto$name'              : 'name',
   'gphoto$numphotos'         : 'num_photos',
@@ -205,13 +206,20 @@ function parseEntry (entry, schema) {
     const key = schema[schemaKey]
 
     if (key) {
-      const value = checkParam(entry[schemaKey]);
-
+      const value = extractValue(entry, schemaKey, key);
       photo[key] = value;
     }
   })
 
   return photo
+}
+
+function extractValue(entry, schemaKey){
+  if(schemaKey.indexOf('.') !== -1){
+    const tempKey = schemaKey.split('.')[0];
+    return extractValue(checkParam(entry[tempKey]), schemaKey.replace(`${tempKey}.`, ''));
+  }
+  return checkParam(entry[schemaKey]);
 }
 
 function getAuthURL (config) {

--- a/src/picasa.js
+++ b/src/picasa.js
@@ -176,7 +176,9 @@ const albumSchema = {
   'title'                    : 'title',
   'summary'                  : 'summary',
   'gphoto$location'          : 'location',
-  'gphoto$nickname'          : 'nickname'
+  'gphoto$nickname'          : 'nickname',
+  'rights'                   : 'rights',
+  'gphoto$access'            : 'access'
 }
 
 const photoSchema = {

--- a/src/picasa.test.js
+++ b/src/picasa.test.js
@@ -54,7 +54,16 @@ describe('Picasa', () => {
             },
             "gphoto$nickname":{  
                "$t":"BobDeBouwer"
-            }
+            },
+            "media$group":{
+              "media$thumbnail":[  
+                 {  
+                    "url":"https://lh3.googleusercontent.com/-kyCVqkqZt3A/WA61zE/AAAAAAE0/d3cg_CP_Te41PxQJQ1ASGp4r2hGzH_TrgCHMYCg/s160-c/6401011308785",
+                    "height":160,
+                    "width":160
+                 }
+              ]
+           }
          }
         ]
       }
@@ -94,7 +103,7 @@ describe('Picasa', () => {
       expect(albums[0].location).to.be.equals('Utrecht')
       expect(albums[0].rights).to.be.equals('protected')
       expect(albums[0].access).to.be.equals('protected')
-
+      expect(albums[0].thumbnail[0].url).to.be.equals('https://lh3.googleusercontent.com/-kyCVqkqZt3A/WA61zE/AAAAAAE0/d3cg_CP_Te41PxQJQ1ASGp4r2hGzH_TrgCHMYCg/s160-c/6401011308785')
     })
 
     it('should make a get request', () => {

--- a/src/picasa.test.js
+++ b/src/picasa.test.js
@@ -20,6 +20,100 @@ describe('Picasa', () => {
 
   beforeEach(() => picasa = new Picasa())
 
+  describe('getAlbums', () => {
+    const fakeSuccessBody = {
+      "feed":{
+        "entry":[
+          {
+            "published":{  
+               "$t":"2017-03-24T10:33:16.000Z"
+            },
+            "title":{  
+               "$t":"A test album"
+            },
+            "summary":{  
+               "$t":"Not much"
+            },
+            "rights":{  
+               "$t":"protected"
+            },
+            "gphoto$id":{  
+               "$t":"6401011366244305685"
+            },
+            "gphoto$name":{  
+               "$t":"6401011366244308786"
+            },
+            "gphoto$location":{  
+               "$t":"Utrecht"
+            },
+            "gphoto$access":{  
+               "$t":"protected"
+            },
+            "gphoto$numphotos":{  
+               "$t":420
+            },
+            "gphoto$nickname":{  
+               "$t":"BobDeBouwer"
+            }
+         }
+        ]
+      }
+    }
+
+    let albums
+
+    beforeEach((done) => {
+      stub = sinon.stub(picasa, 'executeRequest')
+      stub.callsArgWithAsync(2, null, fakeSuccessBody)
+
+      const accessToken = 'ya29.OwJqqa1Y2tivkkCWWvA8vt5ltKsdf9cDQ5IRNrTbIt-mcfr5xNj4dQu41K6hZa7lX9O-gw'
+
+      picasa.getAlbums(accessToken, null, (error, albumsResponse) => {
+        expect(error).to.be.equals(null)
+        albums = albumsResponse
+
+        done()
+      })
+    })
+
+    afterEach(() => stub.restore())
+
+    it('returns an array of albums', () => {
+      expect(albums).to.be.an('Array')
+    })
+
+    it('returns albums with its props', () => {
+      expect(albums.length).to.be.equals(1)
+      expect(albums[0].title).to.be.equals('A test album')
+      expect(albums[0].nickname).to.be.equals('BobDeBouwer')
+      expect(albums[0].id).to.be.equals('6401011366244305685')
+      expect(albums[0].name).to.be.equals('6401011366244308786')
+      expect(albums[0].num_photos).to.be.equals(420)
+      expect(albums[0].published).to.be.equals('2017-03-24T10:33:16.000Z')
+      expect(albums[0].summary).to.be.equals('Not much')
+      expect(albums[0].location).to.be.equals('Utrecht')
+      expect(albums[0].rights).to.be.equals('protected')
+      expect(albums[0].access).to.be.equals('protected')
+
+    })
+
+    it('should make a get request', () => {
+      const firstArgument = stub.args[0][0]
+
+      expect(firstArgument).to.be.eql('get')
+    })
+
+    it('should add a header and prepared URL to the request', () => {
+      const secondArgument = stub.args[0][1]
+
+      expect(secondArgument).to.be.eql({
+        headers : { 'GData-Version': "2" },
+        url     : "https://picasaweb.google.com/data/feed/api/user/default?alt=json&access_token=ya29.OwJqqa1Y2tivkkCWWvA8vt5ltKsdf9cDQ5IRNrTbIt-mcfr5xNj4dQu41K6hZa7lX9O-gw"
+      })
+    })
+
+  })
+
   describe('getPhotos', () => {
     describe('on success', () => {
       const fakeSuccessBody = {


### PR DESCRIPTION
* Add support for nested keys in the extraction of entries
* Also add thumbnail url to the list of elements extracted for albums.

This PR is minimal, but build up on https://github.com/esteban-uo/picasa/pull/19. It should probably merged after. 

To see the extent of the changes, you can check https://github.com/jlengrand/picasa/pull/1.